### PR TITLE
Add Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: cpp
+compiler:
+  - clang
+notifications:
+  email: false
+env:
+  matrix:
+    - JULIAVERSION="juliareleases"
+    - JULIAVERSION="julianightlies"
+before_install:
+  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
+  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
+  - sudo apt-get update -qq -y
+  - sudo apt-get install julia -y
+script:
+  - julia -e 'Pkg.init(); Pkg.clone(pwd())'
+  - julia test/tests.jl

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/dcjones/Codecs.jl.svg?branch=master)](https://travis-ci.org/dcjones/Codecs.jl)
 
 # Codecs
 


### PR DESCRIPTION
Added a Travis configuration and a build status image for the README.  This adds Travis CI execution of the tests for this repo against the release and nightly builds.  See https://travis-ci.org/analyzere/Codecs.jl for the build (of the analyzere fork) in action.
