### PR TITLE
Add precompile directive

### DIFF
--- a/src/Codecs.jl
+++ b/src/Codecs.jl
@@ -1,3 +1,4 @@
+VERSION >= v"0.4.0-dev+6641" && __precompile__()
 
 module Codecs
 
@@ -362,4 +363,3 @@ end
 
 
 end # module Codecs
-


### PR DESCRIPTION
Passed `Pkg.test` on 0.4. Needed to resolve dependencies during precompilation.
