### PR TITLE
Fix 0.7 depwarns and errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ os:
 notifications:
   email: false
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 before_install:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("Codecs")'
+after_success:
+  - julia -e 'cd(Pkg.dir("Codecs")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
-Compat 0.17.0
+julia 0.5
+Compat 0.27.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -1,8 +1,23 @@
+#
 
-n = [1,4,7,9,11,17,243,5247]
-@test decode(Base64, encode(Base64, reinterpret(UInt8, n))) == reinterpret(UInt8, n)
+const data = [1,4,7,9,11,17,243,5247]
+const data8 = reinterpret(UInt8, data)
+const data_s = String(data8)
 
-for i in n
+function test_encoding(T)
+    en_vec = encode(T, data8)
+    @test encode(T, data_s) == en_vec
+    en_str = String(en_vec)
+    @test decode(T, en_vec) == data8
+    @test decode(T, en_str) == data8
+end
+
+test_encoding(Base64)
+test_encoding(Zlib)
+
+for i in data
     @test decode(BCD, encode(BCD, i)) == i
     @test decode(BCD, encode(BCD, i, true), true) == i
 end
+
+@test isa(Codecs.zlib_version(), String)


### PR DESCRIPTION
* Drop 0.4 support due to Compat requirement
* Improve test coverage
* Fix zlib encode/decode which is broken since 0.4 and test it
* Make `zlib_version` return a `String` instead.
  Returning `VersionNumber` may be better but at least a string is much more useful than a pointer.
* Remove old compat use.
* Enable Codecov